### PR TITLE
Tap Graphite before installing

### DIFF
--- a/ansible/roles/install/tasks/main.yml
+++ b/ansible/roles/install/tasks/main.yml
@@ -8,6 +8,11 @@
     name: gh
     state: present
 
+- name: Tap Graphite repository
+  community.general.homebrew_tap:
+    name: withgraphite/tap
+    state: present
+
 - name: Install Graphite using Homebrew
   community.general.homebrew:
     name: withgraphite/tap/graphite


### PR DESCRIPTION
### TL;DR

Added Homebrew tap step for Graphite installation

### What changed?

Added a new task to explicitly tap the Graphite repository (`withgraphite/tap`) before installing the Graphite package. This ensures the tap is properly set up before attempting to install the package.

### How to test?

1. Run the Ansible playbook with the install role
2. Verify that both the tap and Graphite are installed correctly
3. Check that `gh` and Graphite commands work as expected

### Why make this change?

This change follows Homebrew best practices by explicitly tapping the repository before installation. This prevents potential installation failures that could occur if the tap isn't properly registered, making the installation process more robust and reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Ensured the Graphite Homebrew repository is tapped before installing the Graphite package during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->